### PR TITLE
Update image with the patched one

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   envoy:
-    image: envoyproxy/envoy:v1.18.3
+    image: dio123/envoy:issue-16629
     ports:
       - "8080:8080"
     volumes:

--- a/grpc-json-transcoder.yaml
+++ b/grpc-json-transcoder.yaml
@@ -40,6 +40,8 @@ static_resources:
               convert_grpc_status: true
               proto_descriptor: /etc/envoy/proto.bin
           - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
   clusters:
   - name: grpc


### PR DESCRIPTION
I accommodated the patch from https://github.com/envoyproxy/envoy/issues/16629#issuecomment-1275301361. Seems to be working.

```
$ curl --http2-prior-knowledge http://127.0.0.1:8080/v1alpha1/foo/bar.git/git-upload-pack -H "Content-Type: text/plain" --data 'foobar' 
{
 "code": 13,
 "message": "internal",
 "details": []
}
```

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>